### PR TITLE
- WoW Interface allows to buy a maximum of 255 items per call.

### DIFF
--- a/modules/merchant.lua
+++ b/modules/merchant.lua
@@ -201,7 +201,13 @@ function module:AutoStock()
 
 	-- Buy shopping cart.
 	for item, qty in pairs(cart) do
+		local maxItemCountThatCanBeBoughtAtOnce = 255
 		-- But item.
+		while qty > maxItemCountThatCanBeBoughtAtOnce do
+			BuyMerchantItem(item, maxItemCountThatCanBeBoughtAtOnce)
+			qty = qty - maxItemCountThatCanBeBoughtAtOnce
+		end
+
 		BuyMerchantItem(item, qty)
 	end
 


### PR DESCRIPTION
Added a loop to call buy merchant multiple times when it should buy more than 255 items