### PR TITLE
Fix aura counts, stop initial error for vertex color in buffs

### DIFF
--- a/modules/auras/auras.lua
+++ b/modules/auras/auras.lua
@@ -247,7 +247,7 @@ do
 
 	function WeaponEnchant:Update(enchantNum, unit, invSlotId)
 	    local texture = GetInventoryItemTexture(unit, invSlotId);
-		self.icon:SetTexture(texture)
+	    self.icon:SetTexture(texture)
 		local inventoryItemQuality = GetInventoryItemQuality(unit, invSlotId)
 		if(inventoryItemQuality) then
 		    local r, g, b, hex = GetItemQualityColor(inventoryItemQuality)

--- a/modules/auras/auras.lua
+++ b/modules/auras/auras.lua
@@ -263,7 +263,7 @@ do
 			    self:SetScript('OnUpdate', self.OnUpdate)
 		    else
 		    	self:SetScript('OnUpdate', nil)
-				self.duration:SetText()
+		    	self.duration:SetText()
 		    end
 		end
 	end

--- a/modules/auras/auras.lua
+++ b/modules/auras/auras.lua
@@ -263,7 +263,7 @@ do
 			    self:SetScript('OnUpdate', self.OnUpdate)
 		    else
 		    	self:SetScript('OnUpdate', nil)
-			    self.duration:SetText()
+				self.duration:SetText()
 		    end
 		end
 	end

--- a/modules/auras/auras.lua
+++ b/modules/auras/auras.lua
@@ -246,8 +246,8 @@ do
 	end
 
 	function WeaponEnchant:Update(enchantNum, unit, invSlotId)
-	    local texture = GetInventoryItemTexture(unit, invSlotId);
-	    self.icon:SetTexture(texture)
+		local texture = GetInventoryItemTexture(unit, invSlotId);
+		self.icon:SetTexture(texture)
 		local inventoryItemQuality = GetInventoryItemQuality(unit, invSlotId)
 		if(inventoryItemQuality) then
 		    local r, g, b, hex = GetItemQualityColor(inventoryItemQuality)

--- a/modules/auras/auras.lua
+++ b/modules/auras/auras.lua
@@ -245,22 +245,26 @@ do
 		self.count:SetFormattedText("%d", charges)
 	end
 
-	function WeaponEnchant:Update(enchantNum, ...)
-		self.icon:SetTexture(GetInventoryItemTexture(...))
-		local borderColorR, borderColorG, borderColorB = (GetItemQualityColor(GetInventoryItemQuality(...)) or 1)
-		self.border:SetVertexColor(borderColorR, borderColorG, borderColorB, 1)
-		local remaining, charges = weaponInfo(enchantNum)
-		if charges and charges > 1 then
-			self.enchantNum = enchantNum
-			self.nextUpdate = 0 -- force an update
-			self:SetScript('OnUpdate', self.OnUpdate_Charges)
-		elseif remaining then
-			self.remaining = remaining / 1000
-			self.nextUpdate = nil -- force an update
-			self:SetScript('OnUpdate', self.OnUpdate)
-		else
-			self:SetScript('OnUpdate', nil)
-			self.duration:SetText()
+	function WeaponEnchant:Update(enchantNum, unit, invSlotId)
+	    local texture = GetInventoryItemTexture(unit, invSlotId);
+		self.icon:SetTexture(texture)
+		local inventoryItemQuality = GetInventoryItemQuality(unit, invSlotId)
+		if(inventoryItemQuality) then
+		    local r, g, b, hex = GetItemQualityColor(inventoryItemQuality)
+		    self.border:SetVertexColor(r, g, b)
+		    local remaining, charges = weaponInfo(enchantNum)
+		    if charges and charges > 1 then
+			    self.enchantNum = enchantNum
+			    self.nextUpdate = 0 -- force an update
+			    self:SetScript('OnUpdate', self.OnUpdate_Charges)
+		    elseif remaining then
+			    self.remaining = remaining / 1000
+			    self.nextUpdate = nil -- force an update
+			    self:SetScript('OnUpdate', self.OnUpdate)
+		    else
+		    	self:SetScript('OnUpdate', nil)
+			    self.duration:SetText()
+		    end
 		end
 	end
 

--- a/modules/auras/auras.lua
+++ b/modules/auras/auras.lua
@@ -262,8 +262,8 @@ do
 			    self.nextUpdate = nil -- force an update
 			    self:SetScript('OnUpdate', self.OnUpdate)
 		    else
-				self:SetScript('OnUpdate', nil)
-				self.duration:SetText()
+			    self:SetScript('OnUpdate', nil)
+			    self.duration:SetText()
 		    end
 		end
 	end

--- a/modules/auras/auras.lua
+++ b/modules/auras/auras.lua
@@ -262,8 +262,8 @@ do
 			    self.nextUpdate = nil -- force an update
 			    self:SetScript('OnUpdate', self.OnUpdate)
 		    else
-		    	self:SetScript('OnUpdate', nil)
-		    	self.duration:SetText()
+				self:SetScript('OnUpdate', nil)
+				self.duration:SetText()
 		    end
 		end
 	end

--- a/modules/unitframes/core/elements/aura.lua
+++ b/modules/unitframes/core/elements/aura.lua
@@ -226,7 +226,9 @@ local updateIcon = function(unit, icons, index, offset, filter, isDebuff, visibl
 			icon.icon:SetTexture(texture)
 			if(count > 1 and count) then
 				icon.count:SetText(count)
-			 end
+			else
+			    icon.count:SetText()
+		    end
 
 			local size = icons.size or 16
 			icon:SetSize(size, size)


### PR DESCRIPTION
For the incorrect aura stacking issue, it seems that in `aura.lua:UpdateAuras` `self.Auras` is nil so that whole block is not being triggered, there's quite a bit going on in there which isn't running.. the else block will set the text back to nothing to prevent the incorrect stacks shown.

For the random setVertexColor issue, during startup `inventoryItemQuality` is nil somehow, the else block will just prevent the code from executing which just stops the error. It eventually resolves, couldn't figure out why this is happening.